### PR TITLE
Add provider-neutral AI daily interpretation foundation

### DIFF
--- a/backend/SmartMoney.Application.Tests/AI/MarketInterpretationFoundationTests.cs
+++ b/backend/SmartMoney.Application.Tests/AI/MarketInterpretationFoundationTests.cs
@@ -1,0 +1,408 @@
+using SmartMoney.Application.Scoring;
+using SmartMoney.Domain.Enums;
+using SmartMoney.Job.AI;
+using SmartMoney.Job.Export;
+using System.Text.Json;
+using Xunit;
+
+namespace SmartMoney.Application.Tests.AI;
+
+public sealed class MarketInterpretationFoundationTests
+{
+    private static readonly MarketInterpretationResult ValidResult = new(
+        "The setup is mixed and the canonical direction remains Neutral.",
+        "FII is the main participant driver while Futures is the dominant indicator.",
+        "Mixed participant evidence limits confidence.");
+
+    [Fact]
+    public void InputFactory_MapsEveryApprovedFieldExactly()
+    {
+        var decomposition = Decomposition();
+
+        var input = MarketInterpretationInputFactory.Create(
+            "2026-08-18", 22.5, "Neutral", "Mild", "NORMAL", 1.25,
+            decomposition, "Authoritative explanation.");
+
+        Assert.Equal("2026-08-18", input.signal_date);
+        Assert.Equal(22.5, input.final_score);
+        Assert.Equal("Neutral", input.displayed_direction);
+        Assert.Equal("Mild", input.strength);
+        Assert.Equal("NORMAL", input.regime);
+        Assert.Equal(1.25, input.shock_score);
+        Assert.Equal("FII", input.main_participant_driver);
+        Assert.Equal(decomposition.participant_contributions.Select(x => (x.name, x.contribution)),
+            input.participant_contributions.Select(x => (x.name, x.contribution)));
+        Assert.Equal("Futures", input.main_indicator_driver);
+        Assert.Equal(decomposition.indicator_contributions.Select(x => (x.name, x.contribution)),
+            input.indicator_contributions.Select(x => (x.name, x.contribution)));
+        Assert.Equal(0.7, input.smart_bias);
+        Assert.Equal(-0.2, input.retail_bias);
+        Assert.Equal(0.1, input.dii_bias);
+        Assert.Equal(0.9, input.smart_retail_divergence);
+        Assert.Equal(0.6, input.smart_dii_divergence);
+        Assert.Equal("SmartBullRetailBear", input.smart_retail_state);
+        Assert.Equal(0.65, input.participant_concentration);
+        Assert.Equal("Mixed", input.participant_alignment);
+        Assert.Equal("Aligned", input.indicator_alignment);
+        Assert.Equal("Agree", input.dii_smart_relationship);
+        Assert.Equal("Authoritative explanation.", input.deterministic_explanation);
+    }
+
+    [Fact]
+    public void Fingerprint_IdenticalInputAndContext_IsStable()
+    {
+        var first = Fingerprint(Input(), Context());
+        var second = Fingerprint(Input(), Context());
+
+        Assert.Equal(first, second);
+        Assert.StartsWith("sha256:", first);
+        Assert.Equal(71, first.Length);
+    }
+
+    [Theory]
+    [InlineData("input")]
+    [InlineData("prompt_version")]
+    [InlineData("prompt_content")]
+    [InlineData("model")]
+    [InlineData("generation_setting")]
+    public void Fingerprint_ResponseAffectingChange_Invalidates(string change)
+    {
+        var input = Input();
+        var context = Context();
+        var changedInput = change == "input" ? input with { shock_score = input.shock_score + 0.01 } : input;
+        var changedContext = change switch
+        {
+            "prompt_version" => context with { prompt_version = "market-daily-v2" },
+            "prompt_content" => context with { prompt_content = context.prompt_content + " changed" },
+            "model" => context with { model = "model-b" },
+            "generation_setting" => context with
+            {
+                generation_settings = new Dictionary<string, string> { ["temperature"] = "0.2" }
+            },
+            _ => context
+        };
+
+        Assert.NotEqual(Fingerprint(input, context), Fingerprint(changedInput, changedContext));
+    }
+
+    [Fact]
+    public async Task Fingerprint_TimeoutChange_DoesNotInvalidate()
+    {
+        var first = await GenerateWithOptions(new MarketInterpretationOptions
+        {
+            Enabled = true, Provider = "fake", Model = "model-a", TimeoutSeconds = 5
+        });
+        var second = await GenerateWithOptions(new MarketInterpretationOptions
+        {
+            Enabled = true, Provider = "fake", Model = "model-a", TimeoutSeconds = 50
+        });
+
+        Assert.Equal(first!.input_fingerprint, second!.input_fingerprint);
+    }
+
+    [Fact]
+    public async Task Service_Disabled_ReturnsNoAttemptAndDoesNotCallProvider()
+    {
+        var provider = new FakeProvider(ValidResult);
+        var service = Service(provider, new MarketInterpretationOptions { Enabled = false });
+
+        var attempt = await service.InterpretAsync(Input(), null, CancellationToken.None);
+
+        Assert.Null(attempt);
+        Assert.Equal(0, provider.CallCount);
+    }
+
+    [Fact]
+    public void JsonContract_NullInterpretationIsOmitted()
+    {
+        var dto = new MarketTodayDto(
+            "NIFTY", "2026-08-18", 22.5, "NORMAL", 1.25, []);
+
+        var json = JsonSerializer.Serialize(dto);
+
+        Assert.DoesNotContain("ai_interpretation", json);
+    }
+
+    [Fact]
+    public void Validator_AcceptsValidStructuredResult()
+    {
+        var validation = new MarketInterpretationValidator().Validate(ValidResult, Input());
+
+        Assert.True(validation.is_valid);
+        Assert.Empty(validation.errors);
+    }
+
+    [Theory]
+    [InlineData("summary")]
+    [InlineData("key_observation")]
+    [InlineData("uncertainty")]
+    public void Validator_RejectsMissingRequiredField(string field)
+    {
+        var result = field switch
+        {
+            "summary" => ValidResult with { summary = " " },
+            "key_observation" => ValidResult with { key_observation = "" },
+            _ => ValidResult with { uncertainty = "\t" }
+        };
+
+        Assert.Contains($"{field}_required", Errors(result));
+    }
+
+    [Fact]
+    public void Validator_RejectsPerFieldAndCombinedLengthLimits()
+    {
+        Assert.Contains("summary_too_long", Errors(ValidResult with { summary = new string('a', 401) }));
+
+        var combined = new MarketInterpretationResult(
+            new string('a', 350), new string('b', 350), new string('c', 350));
+        Assert.Contains("combined_text_too_long", Errors(combined));
+    }
+
+    [Theory]
+    [InlineData("Buy the index.")]
+    [InlineData("This is a sell signal.")]
+    [InlineData("Investors should hold.")]
+    [InlineData("The price target is higher.")]
+    [InlineData("This is a guaranteed outcome.")]
+    [InlineData("You should enter a trade.")]
+    [InlineData("Enter the market now.")]
+    public void Validator_RejectsTradingLanguage(string prose)
+        => Assert.Contains("trading_recommendation", Errors(ValidResult with { summary = prose }));
+
+    [Theory]
+    [InlineData("The score is 25.")]
+    [InlineData("Confidence is 50%.")]
+    [InlineData("The value is minus 2.5 points.")]
+    public void Validator_RejectsNumericClaims(string prose)
+        => Assert.Contains("numeric_claim", Errors(ValidResult with { summary = prose }));
+
+    [Theory]
+    [InlineData("The market will rise.")]
+    [InlineData("The market could fall.")]
+    [InlineData("A rally is expected to continue.")]
+    [InlineData("This forecasts a decline.")]
+    public void Validator_RejectsUnsupportedPrediction(string prose)
+        => Assert.Contains("unsupported_prediction", Errors(ValidResult with { summary = prose }));
+
+    [Fact]
+    public void Validator_RejectsDirectionContradiction()
+        => Assert.Contains("direction_contradiction",
+            Errors(ValidResult with { summary = "The setup is Bearish." }));
+
+    [Fact]
+    public void Validator_RejectsRegimeContradiction()
+        => Assert.Contains("regime_contradiction",
+            Errors(ValidResult with { summary = "The Shock regime dominates." }));
+
+    [Fact]
+    public void Validator_RejectsWrongDominantParticipant()
+        => Assert.Contains("participant_driver_contradiction",
+            Errors(ValidResult with { key_observation = "DII is the dominant participant." }));
+
+    [Fact]
+    public void Validator_RejectsWrongDominantIndicator()
+        => Assert.Contains("indicator_driver_contradiction",
+            Errors(ValidResult with { key_observation = "Calls are the largest indicator driver." }));
+
+    [Theory]
+    [InlineData("News supports this setup.")]
+    [InlineData("Earnings explain the alignment.")]
+    [InlineData("A policy announcement is relevant.")]
+    [InlineData("An economic event caused this.")]
+    public void Validator_RejectsExternalFacts(string prose)
+        => Assert.Contains("external_fact_reference", Errors(ValidResult with { summary = prose }));
+
+    [Fact]
+    public async Task Service_ProviderUnavailable_IsNonBlocking()
+    {
+        var service = Service(
+            new DisabledMarketInterpretationProvider(),
+            new MarketInterpretationOptions { Enabled = true, Provider = "disabled", Model = "none" });
+
+        var attempt = await service.InterpretAsync(Input(), null, CancellationToken.None);
+
+        Assert.Equal(MarketInterpretationStatus.Unavailable, attempt!.status);
+        Assert.Equal("provider_unavailable", attempt.failure_category);
+        Assert.Null(attempt.interpretation);
+    }
+
+    [Fact]
+    public async Task Service_MalformedProviderResponse_IsInvalid()
+    {
+        var service = Service(new FakeProvider(null), EnabledOptions());
+
+        var attempt = await service.InterpretAsync(Input(), null, CancellationToken.None);
+
+        Assert.Equal(MarketInterpretationStatus.Invalid, attempt!.status);
+        Assert.Contains("response_missing", attempt.failure_category);
+    }
+
+    [Fact]
+    public async Task Service_SameFingerprintAndValidResult_IsReusedWithoutProviderCall()
+    {
+        var provider = new FakeProvider(ValidResult);
+        var service = Service(provider, EnabledOptions());
+        var generated = await service.InterpretAsync(Input(), null, CancellationToken.None);
+
+        var reused = await service.InterpretAsync(Input(), generated, CancellationToken.None);
+
+        Assert.Equal(MarketInterpretationStatus.Reused, reused!.status);
+        Assert.Equal(generated!.generated_at, reused.generated_at);
+        Assert.Equal(1, provider.CallCount);
+    }
+
+    [Fact]
+    public async Task Service_MatchingFingerprintWithInvalidCachedText_IsNotReused()
+    {
+        var provider = new FakeProvider(ValidResult);
+        var service = Service(provider, EnabledOptions());
+        var generated = await service.InterpretAsync(Input(), null, CancellationToken.None);
+        var invalidCached = generated! with
+        {
+            interpretation = ValidResult with { summary = "Buy the index." }
+        };
+
+        var attempt = await service.InterpretAsync(Input(), invalidCached, CancellationToken.None);
+
+        Assert.Equal(MarketInterpretationStatus.Generated, attempt!.status);
+        Assert.Equal(2, provider.CallCount);
+    }
+
+    [Theory]
+    [InlineData("input")]
+    [InlineData("prompt")]
+    [InlineData("model")]
+    public async Task Service_ChangedFingerprint_DoesNotReuse(string change)
+    {
+        var firstProvider = new FakeProvider(ValidResult);
+        var firstService = Service(firstProvider, EnabledOptions());
+        var generated = await firstService.InterpretAsync(Input(), null, CancellationToken.None);
+
+        var secondProvider = new FakeProvider(ValidResult);
+        var secondOptions = EnabledOptions();
+        if (change == "model") secondOptions.Model = "model-b";
+        var secondPrompt = change == "prompt"
+            ? new MarketInterpretationPrompt("market-daily-v2", "prompt-v2")
+            : Prompt();
+        var secondService = Service(secondProvider, secondOptions, secondPrompt);
+        var secondInput = change == "input" ? Input() with { smart_bias = 0.8 } : Input();
+
+        var attempt = await secondService.InterpretAsync(secondInput, generated, CancellationToken.None);
+
+        Assert.Equal(MarketInterpretationStatus.Generated, attempt!.status);
+        Assert.Equal(1, secondProvider.CallCount);
+    }
+
+    [Fact]
+    public async Task Interpretation_DoesNotChangeDeterministicExplanationOrScoringOutputs()
+    {
+        var scoring = new MarketScoringCalculator();
+        var biases = new Dictionary<ParticipantType, double>
+        {
+            [ParticipantType.FII] = 1.2,
+            [ParticipantType.Pro] = -0.5,
+            [ParticipantType.DII] = 0.8,
+            [ParticipantType.Retail] = 0.0
+        };
+        var raw = scoring.ComputeMarketRawScore(biases);
+        var final = scoring.ComputeFinalScore(raw);
+        var regime = scoring.ComputeRegime(1.7);
+        var explanation = MarketNarrative.Explanation("SHOCK", 1.7, final, Decomposition());
+        var service = Service(new FakeProvider(ValidResult), EnabledOptions());
+
+        _ = await service.InterpretAsync(Input() with { deterministic_explanation = explanation }, null, CancellationToken.None);
+
+        Assert.Equal(raw, scoring.ComputeMarketRawScore(biases));
+        Assert.Equal(final, scoring.ComputeFinalScore(raw));
+        Assert.Equal(regime, scoring.ComputeRegime(1.7));
+        Assert.Equal(explanation, MarketNarrative.Explanation("SHOCK", 1.7, final, Decomposition()));
+    }
+
+    private static IReadOnlyList<string> Errors(MarketInterpretationResult result)
+        => new MarketInterpretationValidator().Validate(result, Input()).errors;
+
+    private static string Fingerprint(
+        MarketInterpretationInput input,
+        MarketInterpretationFingerprintContext context)
+        => MarketInterpretationFingerprint.Compute(input, context);
+
+    private static MarketInterpretationFingerprintContext Context() => new(
+        "market-daily-v1",
+        "prompt-v1",
+        "fake",
+        "model-a",
+        new Dictionary<string, string> { ["temperature"] = "0" });
+
+    private static MarketInterpretationInput Input() => MarketInterpretationInputFactory.Create(
+        "2026-08-18", 22.5, "Neutral", "Mild", "NORMAL", 1.25,
+        Decomposition(), "Authoritative explanation.");
+
+    private static MarketNarrativeDecomposition Decomposition() => new(
+        participant_contributions:
+        [
+            new ContributionDto("FII", 0.4),
+            new ContributionDto("PRO", -0.1),
+            new ContributionDto("DII", 0.05),
+            new ContributionDto("RETAIL", -0.02)
+        ],
+        main_participant_driver: "FII",
+        indicator_contributions:
+        [
+            new ContributionDto("Futures", 0.3),
+            new ContributionDto("Puts", 0.1),
+            new ContributionDto("Calls", -0.05)
+        ],
+        main_indicator_driver: "Futures",
+        participant_counts: new SignCountsDto(2, 2, 0),
+        indicator_counts: new SignCountsDto(2, 1, 0),
+        participant_concentration: 0.65,
+        participant_alignment: "Mixed",
+        indicator_alignment: "Aligned",
+        dii_smart_relationship: "Agree",
+        smart_bias: 0.7,
+        retail_bias: -0.2,
+        dii_bias: 0.1,
+        smart_retail_divergence: 0.9,
+        smart_dii_divergence: 0.6,
+        smart_retail_state: "SmartBullRetailBear");
+
+    private static MarketInterpretationOptions EnabledOptions() => new()
+    {
+        Enabled = true,
+        Provider = "fake",
+        Model = "model-a",
+        TimeoutSeconds = 5,
+        PromptVersion = "market-daily-v1",
+        GenerationSettings = new Dictionary<string, string> { ["temperature"] = "0" }
+    };
+
+    private static MarketInterpretationPrompt Prompt() => new("market-daily-v1", "prompt-v1");
+
+    private static MarketInterpretationService Service(
+        IMarketInterpretationProvider provider,
+        MarketInterpretationOptions options,
+        MarketInterpretationPrompt? prompt = null) => new(
+            provider,
+            new MarketInterpretationValidator(),
+            options,
+            prompt ?? Prompt(),
+            TimeProvider.System);
+
+    private static Task<MarketInterpretationAttempt?> GenerateWithOptions(MarketInterpretationOptions options)
+        => Service(new FakeProvider(ValidResult), options)
+            .InterpretAsync(Input(), null, CancellationToken.None);
+
+    private sealed class FakeProvider(MarketInterpretationResult? result) : IMarketInterpretationProvider
+    {
+        public int CallCount { get; private set; }
+
+        public Task<MarketInterpretationResult?> GenerateAsync(
+            MarketInterpretationInput input,
+            MarketInterpretationPrompt prompt,
+            CancellationToken ct)
+        {
+            CallCount++;
+            return Task.FromResult(result);
+        }
+    }
+}

--- a/backend/SmartMoney.Job/AI/MarketInterpretationContracts.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationContracts.cs
@@ -1,0 +1,68 @@
+namespace SmartMoney.Job.AI;
+
+public sealed record MarketInterpretationContribution(
+    string name,
+    double contribution);
+
+public sealed record MarketInterpretationInput(
+    string signal_date,
+    double final_score,
+    string displayed_direction,
+    string strength,
+    string regime,
+    double shock_score,
+    IReadOnlyList<MarketInterpretationContribution> participant_contributions,
+    string? main_participant_driver,
+    IReadOnlyList<MarketInterpretationContribution> indicator_contributions,
+    string? main_indicator_driver,
+    double smart_bias,
+    double retail_bias,
+    double dii_bias,
+    double smart_retail_divergence,
+    double smart_dii_divergence,
+    string smart_retail_state,
+    double participant_concentration,
+    string participant_alignment,
+    string indicator_alignment,
+    string dii_smart_relationship,
+    string deterministic_explanation);
+
+public sealed record MarketInterpretationResult(
+    string summary,
+    string key_observation,
+    string uncertainty,
+    string? context = null);
+
+public enum MarketInterpretationStatus
+{
+    Generated,
+    Reused,
+    Unavailable,
+    Invalid
+}
+
+public sealed record MarketInterpretationAttempt(
+    MarketInterpretationStatus status,
+    string prompt_version,
+    string input_fingerprint,
+    DateTimeOffset? generated_at = null,
+    MarketInterpretationResult? interpretation = null,
+    string? failure_category = null);
+
+public sealed record MarketInterpretationValidationResult(
+    bool is_valid,
+    IReadOnlyList<string> errors)
+{
+    public static MarketInterpretationValidationResult Valid { get; } = new(true, []);
+}
+
+public sealed record MarketInterpretationFingerprintContext(
+    string prompt_version,
+    string prompt_content,
+    string provider,
+    string model,
+    IReadOnlyDictionary<string, string>? generation_settings = null);
+
+public sealed record MarketInterpretationPrompt(
+    string version,
+    string content);

--- a/backend/SmartMoney.Job/AI/MarketInterpretationFingerprint.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationFingerprint.cs
@@ -1,0 +1,100 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace SmartMoney.Job.AI;
+
+public static class MarketInterpretationFingerprint
+{
+    public const string InputSchemaVersion = "market-interpretation-input-v1";
+    public const string OutputSchemaVersion = "market-interpretation-output-v1";
+
+    public static string Compute(
+        MarketInterpretationInput input,
+        MarketInterpretationFingerprintContext context)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+        ArgumentNullException.ThrowIfNull(context);
+
+        using var stream = new MemoryStream();
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            writer.WriteString("input_schema_version", InputSchemaVersion);
+            WriteInput(writer, input);
+            writer.WriteString("prompt_version", context.prompt_version);
+            writer.WriteString("prompt_content_hash", Hash(context.prompt_content));
+            writer.WriteString("provider", context.provider);
+            writer.WriteString("model", context.model);
+            writer.WriteString("output_schema_version", OutputSchemaVersion);
+            writer.WritePropertyName("generation_settings");
+            writer.WriteStartObject();
+            foreach (var setting in (context.generation_settings ?? new Dictionary<string, string>())
+                         .OrderBy(x => x.Key, StringComparer.Ordinal))
+            {
+                writer.WriteString(setting.Key, setting.Value);
+            }
+            writer.WriteEndObject();
+            writer.WriteEndObject();
+        }
+
+        return $"sha256:{Hash(stream.ToArray())}";
+    }
+
+    private static void WriteInput(Utf8JsonWriter writer, MarketInterpretationInput input)
+    {
+        writer.WritePropertyName("input");
+        writer.WriteStartObject();
+        writer.WriteString("signal_date", input.signal_date);
+        writer.WriteNumber("final_score", input.final_score);
+        writer.WriteString("displayed_direction", input.displayed_direction);
+        writer.WriteString("strength", input.strength);
+        writer.WriteString("regime", input.regime);
+        writer.WriteNumber("shock_score", input.shock_score);
+        WriteContributions(writer, "participant_contributions", input.participant_contributions);
+        WriteNullableString(writer, "main_participant_driver", input.main_participant_driver);
+        WriteContributions(writer, "indicator_contributions", input.indicator_contributions);
+        WriteNullableString(writer, "main_indicator_driver", input.main_indicator_driver);
+        writer.WriteNumber("smart_bias", input.smart_bias);
+        writer.WriteNumber("retail_bias", input.retail_bias);
+        writer.WriteNumber("dii_bias", input.dii_bias);
+        writer.WriteNumber("smart_retail_divergence", input.smart_retail_divergence);
+        writer.WriteNumber("smart_dii_divergence", input.smart_dii_divergence);
+        writer.WriteString("smart_retail_state", input.smart_retail_state);
+        writer.WriteNumber("participant_concentration", input.participant_concentration);
+        writer.WriteString("participant_alignment", input.participant_alignment);
+        writer.WriteString("indicator_alignment", input.indicator_alignment);
+        writer.WriteString("dii_smart_relationship", input.dii_smart_relationship);
+        writer.WriteString("deterministic_explanation", input.deterministic_explanation);
+        writer.WriteEndObject();
+    }
+
+    private static void WriteContributions(
+        Utf8JsonWriter writer,
+        string propertyName,
+        IReadOnlyList<MarketInterpretationContribution> contributions)
+    {
+        writer.WritePropertyName(propertyName);
+        writer.WriteStartArray();
+        foreach (var contribution in contributions)
+        {
+            writer.WriteStartObject();
+            writer.WriteString("name", contribution.name);
+            writer.WriteNumber("contribution", contribution.contribution);
+            writer.WriteEndObject();
+        }
+        writer.WriteEndArray();
+    }
+
+    private static void WriteNullableString(Utf8JsonWriter writer, string propertyName, string? value)
+    {
+        if (value is null)
+            writer.WriteNull(propertyName);
+        else
+            writer.WriteString(propertyName, value);
+    }
+
+    private static string Hash(string value) => Hash(Encoding.UTF8.GetBytes(value));
+
+    private static string Hash(byte[] bytes) => Convert.ToHexString(SHA256.HashData(bytes)).ToLowerInvariant();
+}

--- a/backend/SmartMoney.Job/AI/MarketInterpretationInputFactory.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationInputFactory.cs
@@ -1,0 +1,46 @@
+using SmartMoney.Job.Export;
+
+namespace SmartMoney.Job.AI;
+
+public static class MarketInterpretationInputFactory
+{
+    public static MarketInterpretationInput Create(
+        string signalDate,
+        double finalScore,
+        string displayedDirection,
+        string strength,
+        string regime,
+        double shockScore,
+        MarketNarrativeDecomposition decomposition,
+        string deterministicExplanation)
+    {
+        ArgumentNullException.ThrowIfNull(decomposition);
+
+        return new MarketInterpretationInput(
+            signal_date: signalDate,
+            final_score: finalScore,
+            displayed_direction: displayedDirection,
+            strength: strength,
+            regime: regime,
+            shock_score: shockScore,
+            participant_contributions: decomposition.participant_contributions
+                .Select(x => new MarketInterpretationContribution(x.name, x.contribution))
+                .ToArray(),
+            main_participant_driver: decomposition.main_participant_driver,
+            indicator_contributions: decomposition.indicator_contributions
+                .Select(x => new MarketInterpretationContribution(x.name, x.contribution))
+                .ToArray(),
+            main_indicator_driver: decomposition.main_indicator_driver,
+            smart_bias: decomposition.smart_bias,
+            retail_bias: decomposition.retail_bias,
+            dii_bias: decomposition.dii_bias,
+            smart_retail_divergence: decomposition.smart_retail_divergence,
+            smart_dii_divergence: decomposition.smart_dii_divergence,
+            smart_retail_state: decomposition.smart_retail_state,
+            participant_concentration: decomposition.participant_concentration,
+            participant_alignment: decomposition.participant_alignment,
+            indicator_alignment: decomposition.indicator_alignment,
+            dii_smart_relationship: decomposition.dii_smart_relationship,
+            deterministic_explanation: deterministicExplanation);
+    }
+}

--- a/backend/SmartMoney.Job/AI/MarketInterpretationOptions.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationOptions.cs
@@ -1,0 +1,13 @@
+namespace SmartMoney.Job.AI;
+
+public sealed class MarketInterpretationOptions
+{
+    public bool Enabled { get; set; } = false;
+    public string Provider { get; set; } = "disabled";
+    public string Model { get; set; } = "none";
+    public string? Endpoint { get; set; }
+    public string? ApiCredentialEnvironmentVariable { get; set; }
+    public int TimeoutSeconds { get; set; } = 15;
+    public string PromptVersion { get; set; } = "market-daily-v1";
+    public Dictionary<string, string> GenerationSettings { get; set; } = new(StringComparer.Ordinal);
+}

--- a/backend/SmartMoney.Job/AI/MarketInterpretationService.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationService.cs
@@ -1,0 +1,146 @@
+namespace SmartMoney.Job.AI;
+
+public interface IMarketInterpretationProvider
+{
+    Task<MarketInterpretationResult?> GenerateAsync(
+        MarketInterpretationInput input,
+        MarketInterpretationPrompt prompt,
+        CancellationToken ct);
+}
+
+public interface IMarketInterpretationService
+{
+    Task<MarketInterpretationAttempt?> InterpretAsync(
+        MarketInterpretationInput input,
+        MarketInterpretationAttempt? previous,
+        CancellationToken ct);
+}
+
+public sealed class DisabledMarketInterpretationProvider : IMarketInterpretationProvider
+{
+    public Task<MarketInterpretationResult?> GenerateAsync(
+        MarketInterpretationInput input,
+        MarketInterpretationPrompt prompt,
+        CancellationToken ct) => throw new MarketInterpretationProviderUnavailableException();
+}
+
+public sealed class MarketInterpretationProviderUnavailableException : Exception
+{
+    public MarketInterpretationProviderUnavailableException()
+        : base("No market interpretation provider is configured.")
+    {
+    }
+}
+
+public sealed class MarketInterpretationService : IMarketInterpretationService
+{
+    private readonly IMarketInterpretationProvider provider;
+    private readonly MarketInterpretationValidator validator;
+    private readonly MarketInterpretationOptions options;
+    private readonly MarketInterpretationPrompt prompt;
+    private readonly TimeProvider timeProvider;
+
+    public MarketInterpretationService(
+        IMarketInterpretationProvider provider,
+        MarketInterpretationValidator validator,
+        MarketInterpretationOptions options,
+        MarketInterpretationPrompt prompt,
+        TimeProvider timeProvider)
+    {
+        this.provider = provider;
+        this.validator = validator;
+        this.options = options;
+        this.prompt = prompt;
+        this.timeProvider = timeProvider;
+    }
+
+    public async Task<MarketInterpretationAttempt?> InterpretAsync(
+        MarketInterpretationInput input,
+        MarketInterpretationAttempt? previous,
+        CancellationToken ct)
+    {
+        if (!options.Enabled)
+            return null;
+
+        var fingerprint = MarketInterpretationFingerprint.Compute(
+            input,
+            new MarketInterpretationFingerprintContext(
+                prompt.version,
+                prompt.content,
+                options.Provider,
+                options.Model,
+                options.GenerationSettings));
+
+        if (string.IsNullOrWhiteSpace(prompt.content))
+            return Unavailable(fingerprint, "prompt_unavailable");
+
+        if (CanReuse(previous, fingerprint, input))
+        {
+            return previous! with
+            {
+                status = MarketInterpretationStatus.Reused,
+                prompt_version = prompt.version,
+                input_fingerprint = fingerprint,
+                failure_category = null
+            };
+        }
+
+        try
+        {
+            using var timeout = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            timeout.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, options.TimeoutSeconds)));
+            var result = await provider.GenerateAsync(input, prompt, timeout.Token);
+            var validation = validator.Validate(result, input);
+            if (!validation.is_valid)
+            {
+                return new MarketInterpretationAttempt(
+                    MarketInterpretationStatus.Invalid,
+                    prompt.version,
+                    fingerprint,
+                    failure_category: string.Join(",", validation.errors));
+            }
+
+            return new MarketInterpretationAttempt(
+                MarketInterpretationStatus.Generated,
+                prompt.version,
+                fingerprint,
+                timeProvider.GetUtcNow(),
+                result);
+        }
+        catch (OperationCanceledException)
+        {
+            return Unavailable(fingerprint, ct.IsCancellationRequested ? "cancelled" : "timeout");
+        }
+        catch (MarketInterpretationProviderUnavailableException)
+        {
+            return Unavailable(fingerprint, "provider_unavailable");
+        }
+        catch (Exception)
+        {
+            return Unavailable(fingerprint, "provider_failure");
+        }
+    }
+
+    private bool CanReuse(
+        MarketInterpretationAttempt? previous,
+        string fingerprint,
+        MarketInterpretationInput input)
+    {
+        if (previous is null
+            || previous.status is not (MarketInterpretationStatus.Generated or MarketInterpretationStatus.Reused)
+            || !string.Equals(previous.input_fingerprint, fingerprint, StringComparison.Ordinal)
+            || !string.Equals(previous.prompt_version, prompt.version, StringComparison.Ordinal)
+            || previous.interpretation is null)
+        {
+            return false;
+        }
+
+        return validator.Validate(previous.interpretation, input).is_valid;
+    }
+
+    private MarketInterpretationAttempt Unavailable(string fingerprint, string category) => new(
+        MarketInterpretationStatus.Unavailable,
+        prompt.version,
+        fingerprint,
+        failure_category: category);
+}

--- a/backend/SmartMoney.Job/AI/MarketInterpretationValidator.cs
+++ b/backend/SmartMoney.Job/AI/MarketInterpretationValidator.cs
@@ -1,0 +1,121 @@
+using System.Text.RegularExpressions;
+
+namespace SmartMoney.Job.AI;
+
+public sealed class MarketInterpretationValidator
+{
+    public const int MaximumFieldLength = 400;
+    public const int MaximumCombinedLength = 1000;
+
+    private static readonly Regex NumericClaim = new(
+        @"(?<![\p{L}\p{N}_])[-+]?(?:\d+(?:[.,]\d+)?|\.\d+)%?",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    private static readonly Regex TradingLanguage = new(
+        @"\b(?:buy|buys|buying|sell|sells|selling|hold|holds|holding)\b|\bprice\s+target\b|\bguaranteed?\s+outcome\b|\b(?:guarantee(?:d|s)?|certain)\b|\b(?:you\s+should|should|must|consider|recommend)\s+(?:buy|sell|hold|trade|enter|exit|go|buying|selling|holding|trading|entering|exiting|going)\b|\bgo\s+(?:long|short)\b|\btake\s+(?:a\s+)?position\b|\b(?:enter|exit)\s+(?:the|a)\s+(?:market|trade|position)\b|\btrade\s+(?:the|this)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex PredictionLanguage = new(
+        @"\b(?:predict(?:s|ed|ion)?|forecast(?:s|ed|ing)?|expected\s+to|likely\s+to|(?:will|may|might|could)\s+(?:rise|fall|rally|decline|increase|decrease|gain|drop|move))\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ExternalFacts = new(
+        @"\bnews\b|\bearnings\b|\bpolicy\s+announcements?\b|\beconomic\s+events?\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex Direction = new(
+        @"\b(?<value>bullish|bearish|neutral)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex Regime = new(
+        @"\b(?<value>shock|normal)\b",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex ParticipantDriverClaim = new(
+        @"(?:\b(?<name>FII|PRO|DII|Retail)\b.{0,50}\b(?:largest|main|dominant)\b)|(?:\b(?:largest|main|dominant)\b.{0,50}\b(?<name>FII|PRO|DII|Retail)\b)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    private static readonly Regex IndicatorDriverClaim = new(
+        @"(?:\b(?<name>Futures|Puts|Calls)\b.{0,50}\b(?:largest|main|dominant)\b)|(?:\b(?:largest|main|dominant)\b.{0,50}\b(?<name>Futures|Puts|Calls)\b)",
+        RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.CultureInvariant);
+
+    public MarketInterpretationValidationResult Validate(
+        MarketInterpretationResult? result,
+        MarketInterpretationInput input)
+    {
+        ArgumentNullException.ThrowIfNull(input);
+
+        if (result is null)
+            return new(false, ["response_missing"]);
+
+        var errors = new List<string>();
+        var fields = new (string Name, string? Value, bool Required)[]
+        {
+            ("summary", result.summary, true),
+            ("key_observation", result.key_observation, true),
+            ("uncertainty", result.uncertainty, true),
+            ("context", result.context, false)
+        };
+
+        foreach (var field in fields)
+        {
+            if (field.Required && string.IsNullOrWhiteSpace(field.Value))
+                errors.Add($"{field.Name}_required");
+            if (field.Value?.Length > MaximumFieldLength)
+                errors.Add($"{field.Name}_too_long");
+        }
+
+        var combinedLength = fields.Sum(x => x.Value?.Length ?? 0);
+        if (combinedLength > MaximumCombinedLength)
+            errors.Add("combined_text_too_long");
+
+        var prose = string.Join(" ", fields.Select(x => x.Value).Where(x => !string.IsNullOrWhiteSpace(x)));
+        if (TradingLanguage.IsMatch(prose)) errors.Add("trading_recommendation");
+        if (PredictionLanguage.IsMatch(prose)) errors.Add("unsupported_prediction");
+        if (NumericClaim.IsMatch(prose)) errors.Add("numeric_claim");
+        if (ExternalFacts.IsMatch(prose)) errors.Add("external_fact_reference");
+
+        ValidateClassificationMentions(Direction, prose, input.displayed_direction, "direction_contradiction", errors);
+        ValidateClassificationMentions(Regime, prose, input.regime, "regime_contradiction", errors);
+        ValidateDriverClaims(ParticipantDriverClaim, prose, input.main_participant_driver, "participant_driver_contradiction", errors);
+        ValidateDriverClaims(IndicatorDriverClaim, prose, input.main_indicator_driver, "indicator_driver_contradiction", errors);
+
+        return errors.Count == 0
+            ? MarketInterpretationValidationResult.Valid
+            : new MarketInterpretationValidationResult(false, errors.Distinct(StringComparer.Ordinal).ToArray());
+    }
+
+    private static void ValidateClassificationMentions(
+        Regex regex,
+        string prose,
+        string expected,
+        string error,
+        ICollection<string> errors)
+    {
+        foreach (Match match in regex.Matches(prose))
+        {
+            if (!match.Groups["value"].Value.Equals(expected, StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(error);
+                return;
+            }
+        }
+    }
+
+    private static void ValidateDriverClaims(
+        Regex regex,
+        string prose,
+        string? expected,
+        string error,
+        ICollection<string> errors)
+    {
+        foreach (Match match in regex.Matches(prose))
+        {
+            if (expected is null || !match.Groups["name"].Value.Equals(expected, StringComparison.OrdinalIgnoreCase))
+            {
+                errors.Add(error);
+                return;
+            }
+        }
+    }
+}

--- a/backend/SmartMoney.Job/AI/Prompts/market-daily-interpretation-v1.md
+++ b/backend/SmartMoney.Job/AI/Prompts/market-daily-interpretation-v1.md
@@ -1,0 +1,23 @@
+# Prompt identifier: market-daily-v1
+
+You interpret deterministic SmartMoney market facts supplied in the input object.
+
+The supplied score, displayed direction, strength, regime, ShockScore, drivers, contributions, biases, divergences, alignments, relationships, and deterministic explanation are authoritative. Never recalculate, correct, override, or relabel them.
+
+Return only a structured object with these fields:
+
+- `summary`: required; no more than two concise sentences describing the overall deterministic setup.
+- `key_observation`: required; one genuinely useful structural observation about the supplied drivers, alignment, divergence, concentration, or relationship.
+- `uncertainty`: required; describe mixed or limited model evidence without forecasting an outcome.
+- `context`: optional; concise structural framing only when it adds information distinct from the other fields.
+
+Safety requirements:
+
+- Do not recommend buy, sell, or hold actions.
+- Do not give a price target, trading instruction, guaranteed outcome, or prediction.
+- Do not introduce news, earnings, policy announcements, economic events, prices, macro facts, or any other external information.
+- Do not create numeric claims or perform numeric derivations in the prose.
+- Do not claim a direction or regime different from the supplied canonical values.
+- Do not identify a largest, main, or dominant participant or indicator different from the supplied driver fields.
+- Add interpretation rather than paraphrasing the deterministic explanation sentence by sentence.
+- Keep every field at or below 400 characters and all fields together at or below 1000 characters.

--- a/backend/SmartMoney.Job/Export/MarketDtos.cs
+++ b/backend/SmartMoney.Job/Export/MarketDtos.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace SmartMoney.Job.Export;
 
 public sealed record ParticipantDto(
@@ -11,6 +13,17 @@ public sealed record ParticipantActivityRowDto(
     string instrument,
     double net_oi_change,
     double? vs_yesterday_pct = null
+);
+
+public sealed record AiInterpretationDto(
+    string status,
+    string prompt_version,
+    string? input_fingerprint = null,
+    DateTimeOffset? generated_at = null,
+    string? summary = null,
+    string? key_observation = null,
+    string? uncertainty = null,
+    string? context = null
 );
 
 public sealed record MarketTodayDto(
@@ -35,7 +48,9 @@ public sealed record MarketTodayDto(
     double? smart_retail_divergence = null,
     double? smart_dii_divergence = null,
     string? smart_retail_state = null,
-    MarketNarrativeDecomposition? decomposition = null
+    MarketNarrativeDecomposition? decomposition = null,
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    AiInterpretationDto? ai_interpretation = null
 );
 
 public sealed record MarketHistoryPointDto(

--- a/backend/SmartMoney.Job/Program.cs
+++ b/backend/SmartMoney.Job/Program.cs
@@ -7,6 +7,7 @@ using SmartMoney.Application.Services;
 using SmartMoney.Domain.Entities;
 using SmartMoney.Domain.Enums;
 using SmartMoney.Infrastructure.Persistence;
+using SmartMoney.Job.AI;
 using SmartMoney.Job.Export;
 using System.Text.Json;
 
@@ -68,6 +69,8 @@ namespace SmartMoney.Job
             var repoRoot = FindRepoRoot();
             var publicDataDir = Path.Combine(repoRoot, "frontend", "public", "data");
             var publicMarketTodayPath = Path.Combine(publicDataDir, "market_today.json");
+            var previousAiInterpretation = await ReadExistingAiInterpretationAsync(
+                publicMarketTodayPath, targetDate, log);
 
             bool participantDataAlreadyExported = await CheckExistingExportAsync(publicMarketTodayPath, targetDate, log);
 
@@ -78,6 +81,16 @@ namespace SmartMoney.Job
 
             var (marketToday, history) = await ExportOrReuseParticipantDataAsync(
                 sp, participantDataAlreadyExported, publicDataDir, publicMarketTodayPath, targetDate, log);
+
+            marketToday = await AttachMarketInterpretationAsync(
+                sp, marketToday, previousAiInterpretation, log);
+
+            await SavePatchedJsonAsync(
+                marketToday,
+                history,
+                publicDataDir,
+                publicMarketTodayPath,
+                new JsonSerializerOptions { WriteIndented = true });
 
             await FetchAndPatchPcrVixAsync(
                 sp, marketToday, history, publicDataDir, publicMarketTodayPath, jobOpts, log);
@@ -144,6 +157,14 @@ namespace SmartMoney.Job
                 if (int.TryParse(Environment.GetEnvironmentVariable("PCR_VIX_RETRY_MINUTES"), out var pr)) o.PcrVixRetryMinutes = pr;
             });
 
+            var interpretationOptions = BuildMarketInterpretationOptions();
+            services.AddSingleton(interpretationOptions);
+            services.AddSingleton(LoadMarketInterpretationPrompt(interpretationOptions));
+            services.AddSingleton(TimeProvider.System);
+            services.AddSingleton<MarketInterpretationValidator>();
+            services.AddSingleton<IMarketInterpretationProvider, DisabledMarketInterpretationProvider>();
+            services.AddSingleton<IMarketInterpretationService, MarketInterpretationService>();
+
             services.AddTransient<BhavCopyService>();
             services.AddTransient<OpBhavCopyService>();
             services.AddHttpClient<PrPcrService>();
@@ -154,6 +175,38 @@ namespace SmartMoney.Job
             services.AddScoped<DailyPipelineService>();
 
             return services;
+        }
+
+        private static MarketInterpretationOptions BuildMarketInterpretationOptions()
+        {
+            var options = new MarketInterpretationOptions();
+            if (bool.TryParse(Environment.GetEnvironmentVariable("AI_INTERPRETATION_ENABLED"), out var enabled))
+                options.Enabled = enabled;
+            options.Provider = Environment.GetEnvironmentVariable("AI_INTERPRETATION_PROVIDER") ?? options.Provider;
+            options.Model = Environment.GetEnvironmentVariable("AI_INTERPRETATION_MODEL") ?? options.Model;
+            options.Endpoint = Environment.GetEnvironmentVariable("AI_INTERPRETATION_ENDPOINT");
+            options.ApiCredentialEnvironmentVariable =
+                Environment.GetEnvironmentVariable("AI_INTERPRETATION_API_CREDENTIAL_ENVIRONMENT_VARIABLE");
+            if (int.TryParse(Environment.GetEnvironmentVariable("AI_INTERPRETATION_TIMEOUT_SECONDS"), out var timeoutSeconds))
+                options.TimeoutSeconds = timeoutSeconds;
+            options.PromptVersion =
+                Environment.GetEnvironmentVariable("AI_INTERPRETATION_PROMPT_VERSION") ?? options.PromptVersion;
+            return options;
+        }
+
+        private static MarketInterpretationPrompt LoadMarketInterpretationPrompt(MarketInterpretationOptions options)
+        {
+            const string supportedVersion = "market-daily-v1";
+            if (!string.Equals(options.PromptVersion, supportedVersion, StringComparison.Ordinal))
+                return new MarketInterpretationPrompt(options.PromptVersion, string.Empty);
+
+            var promptPath = Path.Combine(
+                AppContext.BaseDirectory,
+                "AI",
+                "Prompts",
+                "market-daily-interpretation-v1.md");
+            var content = File.Exists(promptPath) ? File.ReadAllText(promptPath) : string.Empty;
+            return new MarketInterpretationPrompt(supportedVersion, content);
         }
 
         private static async Task MigrateDbAsync(ServiceProvider sp)
@@ -711,6 +764,107 @@ namespace SmartMoney.Job
             log.LogWarning("[H3] All PCR sources returned no data for {Date}.", pcrVixDate.ToString("yyyy-MM-dd"));
             return (null, null, null, null);
         }
+
+        private static async Task<AiInterpretationDto?> ReadExistingAiInterpretationAsync(
+            string marketTodayPath,
+            DateTime targetDate,
+            ILogger log)
+        {
+            if (!File.Exists(marketTodayPath)) return null;
+
+            try
+            {
+                var json = await File.ReadAllTextAsync(marketTodayPath);
+                var existing = JsonSerializer.Deserialize<MarketTodayDto>(json);
+                return existing?.date == targetDate.ToString("yyyy-MM-dd")
+                    ? existing.ai_interpretation
+                    : null;
+            }
+            catch (Exception ex)
+            {
+                log.LogWarning("[AI] Existing interpretation could not be read: {Message}", ex.Message);
+                return null;
+            }
+        }
+
+        private static async Task<MarketTodayDto> AttachMarketInterpretationAsync(
+            ServiceProvider sp,
+            MarketTodayDto marketToday,
+            AiInterpretationDto? previousDto,
+            ILogger log)
+        {
+            if (marketToday.decomposition is null
+                || marketToday.explanation is null
+                || marketToday.bias_Label is null
+                || marketToday.strength is null)
+            {
+                log.LogWarning("[AI] Deterministic interpretation inputs are incomplete. AI output omitted.");
+                return marketToday with { ai_interpretation = null };
+            }
+
+            var input = MarketInterpretationInputFactory.Create(
+                marketToday.date,
+                marketToday.final_score,
+                marketToday.bias_Label,
+                marketToday.strength,
+                marketToday.regime,
+                marketToday.shock_score,
+                marketToday.decomposition,
+                marketToday.explanation);
+
+            var service = sp.GetRequiredService<IMarketInterpretationService>();
+            var previous = ToInterpretationAttempt(previousDto ?? marketToday.ai_interpretation);
+            var attempt = await service.InterpretAsync(input, previous, CancellationToken.None);
+
+            if (attempt is null)
+            {
+                log.LogInformation("[AI] Daily interpretation is disabled.");
+                return marketToday with { ai_interpretation = null };
+            }
+
+            log.LogInformation("[AI] Daily interpretation status: {Status}", attempt.status);
+            return marketToday with { ai_interpretation = ToAiInterpretationDto(attempt) };
+        }
+
+        private static MarketInterpretationAttempt? ToInterpretationAttempt(AiInterpretationDto? dto)
+        {
+            if (dto is null
+                || !Enum.TryParse<MarketInterpretationStatus>(dto.status, true, out var status)
+                || dto.input_fingerprint is null)
+            {
+                return null;
+            }
+
+            MarketInterpretationResult? result = null;
+            if (dto.summary is not null
+                || dto.key_observation is not null
+                || dto.uncertainty is not null
+                || dto.context is not null)
+            {
+                result = new MarketInterpretationResult(
+                    dto.summary!,
+                    dto.key_observation!,
+                    dto.uncertainty!,
+                    dto.context);
+            }
+
+            return new MarketInterpretationAttempt(
+                status,
+                dto.prompt_version,
+                dto.input_fingerprint,
+                dto.generated_at,
+                result);
+        }
+
+        private static AiInterpretationDto ToAiInterpretationDto(MarketInterpretationAttempt attempt) => new(
+            status: attempt.status.ToString().ToLowerInvariant(),
+            prompt_version: attempt.prompt_version,
+            input_fingerprint: attempt.input_fingerprint,
+            generated_at: attempt.generated_at,
+            summary: attempt.interpretation?.summary,
+            key_observation: attempt.interpretation?.key_observation,
+            uncertainty: attempt.interpretation?.uncertainty,
+            context: attempt.interpretation?.context);
 
         private static async Task SavePatchedJsonAsync(
             MarketTodayDto marketToday,

--- a/backend/SmartMoney.Job/SmartMoney.Job.csproj
+++ b/backend/SmartMoney.Job/SmartMoney.Job.csproj
@@ -20,4 +20,10 @@
     <ProjectReference Include="..\SmartMoney.Infrastructure\SmartMoney.Infrastructure.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="AI\Prompts\market-daily-interpretation-v1.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/docs/ai-interpretation.md
+++ b/docs/ai-interpretation.md
@@ -1,0 +1,139 @@
+# SmartMoney AI Daily Interpretation
+
+## Status
+
+Phase 7 Step 7.2 provides a provider-neutral foundation. It contains no real AI provider, SDK, credential, or network call. The feature is disabled by default.
+
+## Runtime architecture
+
+The canonical path is:
+
+    SmartMoney.Job
+    -> deterministic scoring
+    -> MarketNarrativeDecomposition
+    -> deterministic V2 explanation
+    -> MarketInterpretationInputFactory
+    -> deterministic fingerprint and reuse check
+    -> optional IMarketInterpretationProvider
+    -> deterministic MarketInterpretationValidator
+    -> optional ai_interpretation in market_today.json
+
+The AI path begins only after all quantitative and presentation values are finalized. It is not referenced by `DailyPipelineService`, `MarketScoringCalculator`, or the decomposition and narrative implementations.
+
+## Responsibility boundary
+
+Deterministic SmartMoney code remains authoritative for FinalScore, RawBias, z-scores, weights, ShockScore, Regime, thresholds, displayed direction and strength, drivers, divergence, alignment, concentration, and backtesting statistics. The deterministic V2 explanation remains the authoritative explanation of model mechanics.
+
+A future AI provider may only add a concise interpretation of the supplied relationships. It must not recalculate, correct, override, or relabel deterministic facts. It must not provide trading recommendations, targets, guaranteed outcomes, forecasts, external facts, or new numeric calculations.
+
+## Input contract
+
+`MarketInterpretationInput` contains only:
+
+- signal date;
+- FinalScore, canonical displayed direction, strength, Regime, and ShockScore;
+- weighted participant contributions and their deterministic main driver;
+- weighted indicator contributions and their deterministic main driver;
+- Smart, Retail, and DII biases;
+- Smart/Retail and Smart/DII divergence and state;
+- participant concentration and participant/indicator alignment;
+- the DII/Smart relationship;
+- the deterministic V2 explanation.
+
+It excludes z-scores, raw positions, weights, PCR, VIX, history, news, macro data, and backtesting metrics. The input factory copies finalized values without rounding or deriving new model facts. Canonical displayed direction comes from the Job's `MarketNarrative.ScoreLabel` result.
+
+## Output contract
+
+A successful validated result contains:
+
+- `summary` (required);
+- `key_observation` (required);
+- `uncertainty` (required);
+- `context` (optional).
+
+Each field is limited to 400 characters and all prose together to 1000 characters. Failure states carry status/provenance only; rejected provider prose is not exported.
+
+Statuses are `generated`, `reused`, `unavailable`, and `invalid`. When disabled, `ai_interpretation` is omitted from serialized `market_today.json`.
+
+## Failure behavior
+
+Provider unavailability, cancellation, timeout, provider exceptions, missing/malformed output, and validation failures are converted into nonthrowing attempts. The deterministic explanation and normal Job outputs are preserved. No fabricated fallback prose is created. AI failure does not change Job success or scoring behavior.
+
+## Fingerprint and reuse
+
+The fingerprint is SHA-256 over canonical UTF-8 JSON with fixed property order and invariant JSON number formatting. It includes:
+
+- input and output schema versions;
+- every interpretation input field;
+- prompt version and prompt-content SHA-256;
+- provider and model/deployment identifiers;
+- response-affecting generation settings sorted by ordinal key.
+
+It excludes credentials, generated timestamps, timeout, and retry configuration.
+
+V1 reuse reads the existing same-date `market_today.json`. Reuse requires an exact fingerprint match, a prior `generated` or `reused` status, and successful current validation of the cached prose. The original `generated_at` value is preserved. There is no database, distributed cache, or new persistence table.
+
+## Configuration
+
+The Job supports these environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `AI_INTERPRETATION_ENABLED` | `false` | Completely enables/disables interpretation |
+| `AI_INTERPRETATION_PROVIDER` | `disabled` | Provider identifier used in the fingerprint |
+| `AI_INTERPRETATION_MODEL` | `none` | Model/deployment identifier used in the fingerprint |
+| `AI_INTERPRETATION_ENDPOINT` | unset | Future provider endpoint |
+| `AI_INTERPRETATION_API_CREDENTIAL_ENVIRONMENT_VARIABLE` | unset | Name/reference of a future credential environment variable, never the secret value |
+| `AI_INTERPRETATION_TIMEOUT_SECONDS` | `15` | Bounded provider timeout; excluded from fingerprint |
+| `AI_INTERPRETATION_PROMPT_VERSION` | `market-daily-v1` | Repository-controlled prompt identifier |
+
+No provider-specific implementation currently consumes endpoint or credential configuration. Secrets must never be committed, logged, fingerprinted, or written to output JSON.
+
+## Validation and safety rules
+
+The deterministic validator rejects:
+
+- missing or blank required fields;
+- per-field or combined length violations;
+- explicit buy, sell, hold, price-target, guarantee, or imperative trading language;
+- unsupported prediction/forecast language;
+- numeric claims in V1 prose;
+- Bullish/Bearish/Neutral mentions contradicting the canonical displayed direction;
+- Shock/Normal mentions contradicting the deterministic Regime;
+- largest/main/dominant participant or indicator claims contradicting deterministic drivers;
+- obvious references to news, earnings, policy announcements, or economic events.
+
+Ordinary invalid content returns structured validation errors and does not throw.
+
+## JSON contract
+
+`market_today.json` may contain:
+
+```json
+{
+  "ai_interpretation": {
+    "status": "generated",
+    "prompt_version": "market-daily-v1",
+    "input_fingerprint": "sha256:...",
+    "generated_at": "2026-08-18T12:34:56+00:00",
+    "summary": "...",
+    "key_observation": "...",
+    "uncertainty": "...",
+    "context": null
+  }
+}
+```
+
+The property is additive and nullable. AI data is not added to `market_history_30.json`, API/controller contracts, or the frontend.
+
+## Runtime prompt
+
+The V1 prompt identifier is `market-daily-v1`. Its repository-controlled source is:
+
+    backend/SmartMoney.Job/AI/Prompts/market-daily-interpretation-v1.md
+
+The Job project copies it into the runtime output directory.
+
+## Test matrix
+
+Automated tests cover exact factory mapping; stable and invalidated fingerprints; timeout exclusion; disabled behavior; valid, missing, oversized, advisory, numeric, predictive, external, classification-conflicting, and driver-conflicting output; provider failure; malformed output; reuse and invalidation; generation timestamp preservation; and invariants that deterministic narrative and scoring values remain unchanged.


### PR DESCRIPTION
## What changed

- added provider-neutral AI Daily Interpretation contracts, input mapping, fingerprinting, validation, reuse, and disabled-provider behavior
- extended `market_today.json` with an optional AI interpretation contract
- added the versioned runtime prompt and Phase 7 documentation
- added comprehensive foundation tests

## Why

This establishes the Phase 7.2 runtime foundation while keeping AI completely downstream of deterministic SmartMoney scoring and without integrating a real provider yet.

## Impact

- AI remains disabled by default and non-blocking
- no scoring formulas, weights, thresholds, decomposition logic, deterministic narrative, frontend, API/controller, or historical JSON contracts changed
- no AI SDK, provider network call, or secret was added

## Validation

- `dotnet build SmartMoney.sln` — passed with 0 warnings and 0 errors
- `dotnet test SmartMoney.sln` — 164 passed, 0 failed, 0 skipped
- `git diff --check` — passed
